### PR TITLE
Update doc string script to parse deprecated methods

### DIFF
--- a/packages/pangea-sdk/pangea/deprecated.py
+++ b/packages/pangea-sdk/pangea/deprecated.py
@@ -1,0 +1,20 @@
+from functools import wraps
+from deprecated import deprecated
+
+def pangea_deprecated(*args, **kwargs):
+    """
+    Use this decorator to mark something as deprecated.
+
+    This is what gets it to show up in our generated SDK docs.
+
+    Example: 
+      @pangea_deprecated(version="1.2.0", reason="Should use FileIntel.hashReputation()")
+      def lookup()
+    """
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*iargs, **ikwargs):
+            return deprecated(*args, **kwargs)(f)(*iargs, **ikwargs)
+        setattr(wrapper, "_deprecated", True)
+        return wrapper
+    return decorator

--- a/packages/pangea-sdk/pangea/services/intel.py
+++ b/packages/pangea-sdk/pangea/services/intel.py
@@ -3,7 +3,7 @@
 import hashlib
 from typing import Dict, List, Optional
 
-from deprecated import deprecated
+from pangea.deprecated import pangea_deprecated
 from pangea.response import APIRequestModel, APIResponseModel, PangeaResponse, PangeaResponseResult
 
 from .base import ServiceBase
@@ -214,7 +214,7 @@ class FileIntel(ServiceBase):
     service_name = "file-intel"
     version = "v1"
 
-    @deprecated(version="1.2.0", reason="Should use FileIntel.hashReputation()")
+    @pangea_deprecated(version="1.2.0", reason="Should use FileIntel.hashReputation()")
     def lookup(
         self,
         hash: str,
@@ -287,7 +287,7 @@ class FileIntel(ServiceBase):
         response.result = FileReputationResult(**response.raw_result)
         return response
 
-    @deprecated(version="1.2.0", reason="Should use FileIntel.filepathReputation()")
+    @pangea_deprecated(version="1.2.0", reason="Should use FileIntel.filepathReputation()")
     def lookupFilepath(
         self,
         filepath: str,
@@ -391,7 +391,7 @@ class DomainIntel(ServiceBase):
     service_name = "domain-intel"
     version = "v1"
 
-    @deprecated(version="1.2.0", reason="Should use DomainIntel.reputation()")
+    @pangea_deprecated(version="1.2.0", reason="Should use DomainIntel.reputation()")
     def lookup(
         self, domain: str, verbose: Optional[bool] = None, raw: Optional[bool] = None, provider: Optional[str] = None
     ) -> PangeaResponse[DomainLookupResult]:
@@ -478,7 +478,7 @@ class IpIntel(ServiceBase):
     service_name = "ip-intel"
     version = "v1"
 
-    @deprecated(version="1.2.0", reason="Should use IpIntel.reputation()")
+    @pangea_deprecated(version="1.2.0", reason="Should use IpIntel.reputation()")
     def lookup(
         self, ip: str, verbose: Optional[bool] = None, raw: Optional[bool] = None, provider: Optional[str] = None
     ) -> PangeaResponse[IPReputationResult]:
@@ -566,7 +566,7 @@ class UrlIntel(ServiceBase):
     service_name = "url-intel"
     version = "v1"
 
-    @deprecated(version="1.2.0", reason="Should use UrlIntel.reputation()")
+    @pangea_deprecated(version="1.2.0", reason="Should use UrlIntel.reputation()")
     def lookup(
         self, url: str, verbose: Optional[bool] = None, raw: Optional[bool] = None, provider: Optional[str] = None
     ) -> PangeaResponse[URLLookupResult]:

--- a/packages/pangea-sdk/parse_module.py
+++ b/packages/pangea-sdk/parse_module.py
@@ -107,6 +107,7 @@ def _parse_function(function, function_cache=set()) -> t.Optional[dict]:
         "examples": [ex.description for ex in parsed_doc.examples],
         "parameters": [],
         "returns": None,
+        "deprecated": getattr(function, "_deprecated", False),
         # "raises": parsed_fn.raises
     }
 


### PR DESCRIPTION
I needed to update our doc string script to provide a boolean for whether or not a doc comment is for a deprecated method.

@ryanmeans did most of the heavy lifting here.

Main takeaway is we should use `pangea_deprecated` going forward instead of `deprecated` so we get access to that deprecated info when generating our SDK documentation.