### PR TITLE
Update readme: close img tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p>
   <br />
   <a href="https://pangea.cloud?utm_source=github&utm_medium=node-sdk" target="_blank" rel="noopener noreferrer">
-    <img src="https://pangea-marketing.s3.us-west-2.amazonaws.com/pangea-color.svg" alt="Pangea Logo" height="40">
+    <img src="https://pangea-marketing.s3.us-west-2.amazonaws.com/pangea-color.svg" alt="Pangea Logo" height="40" />
   </a>
   <br />
 </p>

--- a/packages/pangea-sdk/README.md
+++ b/packages/pangea-sdk/README.md
@@ -1,7 +1,7 @@
 <p>
   <br />
   <a href="https://pangea.cloud?utm_source=github&utm_medium=node-sdk" target="_blank" rel="noopener noreferrer">
-    <img src="https://pangea-marketing.s3.us-west-2.amazonaws.com/pangea-color.svg" alt="Pangea Logo" height="40">
+    <img src="https://pangea-marketing.s3.us-west-2.amazonaws.com/pangea-color.svg" alt="Pangea Logo" height="40" />
   </a>
   <br />
 </p>


### PR DESCRIPTION
Needed to add a close to the img tag, otherwise it breaks the docs website when rendering the readme