### PR TITLE
Try out python 3.10 instead of 3.7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 default:
-  image: python:3.7-bullseye
+  image: python:3.10-bullseye
   tags:
     - pangea-internal
 

--- a/packages/pangea-sdk/pangea/services/authn/authn.py
+++ b/packages/pangea-sdk/pangea/services/authn/authn.py
@@ -105,7 +105,6 @@ class AuthN(ServiceBase):
         ):
             super().__init__(token, config)
             self.session = AuthN.Client.Session(token, config)
-            self.token = AuthN.Client.Token(token, config)
 
         # https://dev.pangea.cloud/docs/api/authn#complete-a-login
         def userinfo(self, code: str) -> PangeaResponse[m.ClientUserinfoResult]:

--- a/packages/pangea-sdk/pangea/services/authn/models.py
+++ b/packages/pangea-sdk/pangea/services/authn/models.py
@@ -391,7 +391,7 @@ class FlowEnrollMFAcompleteResult(CommonFlowResult):
 class FlowEnrollMFAStartRequest(APIRequestModel):
     flow_id: str
     mfa_provider: MFAProvider
-    phone: str
+    phone: Optional[str] = None
 
 
 class FlowEnrollMFAStartResult(CommonFlowResult):

--- a/packages/pangea-sdk/pangea/services/authn/models.py
+++ b/packages/pangea-sdk/pangea/services/authn/models.py
@@ -591,7 +591,7 @@ class ClientSessionInvalidateResult(PangeaResponseResult):
 
 class ClientSessionListRequest(APIRequestModel):
     token: str
-    filter: Optional[dict[str, str]] = None
+    filter: Optional[Dict[str, str]] = None
     last: Optional[str] = None
     order: Optional[ItemOrder] = None
     order_by: Optional[SessionListOrderBy] = None
@@ -603,6 +603,7 @@ class SessionToken(APIResponseModel):
     type: str
     life: int
     expire: str
+    identity: str
     email: str
     scopes: Scopes
     profile: Profile
@@ -610,7 +611,6 @@ class SessionToken(APIResponseModel):
 
 
 class SessionItem(APIResponseModel):
-    # FIXME: Review this and SessionToken
     id: str
     type: str
     life: int

--- a/packages/pangea-sdk/pangea/services/authn/models.py
+++ b/packages/pangea-sdk/pangea/services/authn/models.py
@@ -100,7 +100,7 @@ class UserCreateResult(PangeaResponseResult):
     identity: str
     email: str
     profile: Profile
-    id_provider: str
+    id_provider: Optional[str] = None
     require_mfa: bool
     verified: bool
     last_login_at: Optional[str]
@@ -184,7 +184,7 @@ class LoginToken(APIResponseModel):
     expire: str
     identity: str
     email: str
-    scopes: Scopes
+    scopes: Optional[Scopes] = None
     profile: Profile
     created_at: str
 
@@ -201,8 +201,8 @@ class LoginToken(APIResponseModel):
 
 
 class UserLoginResult(PangeaResponseResult):
-    refresh_token: LoginToken
-    active_token: LoginToken
+    refresh_token: Optional[LoginToken] = None
+    active_token: Optional[LoginToken] = None
 
 
 class UserLoginSocialRequest(APIRequestModel):
@@ -221,7 +221,7 @@ class UserProfileGetResult(PangeaResponseResult):
     identity: str
     email: str
     profile: Profile
-    id_provider: str
+    id_provider: Optional[str] = None
     mfa_providers: List[str]
     require_mfa: bool
     verified: bool
@@ -239,7 +239,7 @@ class UserProfileUpdateResult(PangeaResponseResult):
     identity: str
     email: str
     profile: Profile
-    id_provider: str
+    id_provider: Optional[str] = None
     mfa_providers: List[str]
     require_mfa: bool
     verified: bool
@@ -261,7 +261,7 @@ class UserUpdateResult(PangeaResponseResult):
     email: str
     profile: Profile
     scopes: Optional[Scopes] = None
-    id_provider: IDProvider
+    id_provider: Optional[str] = None
     mfa_providers: Optional[List[str]] = None
     require_mfa: bool
     verified: bool
@@ -538,9 +538,13 @@ class UserMFAStartRequest(APIRequestModel):
     phone: Optional[str] = None
 
 
-class UserMFAStartResult(PangeaResponseResult):
+class UserMFAStartTOTPSecret:
     qr_image: str
     secret: str
+
+
+class UserMFAStartResult(PangeaResponseResult):
+    totp_secret: UserMFAStartTOTPSecret
 
 
 #   - path: authn::/v1/user/mfa/verify
@@ -568,7 +572,7 @@ class UserVerifyResult(PangeaResponseResult):
     email: str
     profile: Profile
     scopes: Scopes
-    id_provider: IDProvider
+    id_provider: Optional[str] = None
     mfa_providers: List[str]
     require_mfa: bool
     verified: bool

--- a/packages/pangea-sdk/pangea/services/authn/models.py
+++ b/packages/pangea-sdk/pangea/services/authn/models.py
@@ -659,7 +659,7 @@ class SessionInvalidateResult(PangeaResponseResult):
 
 
 class SessionListRequest(APIRequestModel):
-    filter: Optional[dict[str, str]] = None
+    filter: Optional[Dict[str, str]] = None
     last: Optional[str] = None
     order: Optional[ItemOrder] = None
     order_by: Optional[SessionListOrderBy] = None

--- a/packages/pangea-sdk/pangea/services/authn/models.py
+++ b/packages/pangea-sdk/pangea/services/authn/models.py
@@ -184,6 +184,7 @@ class LoginToken(APIResponseModel):
     expire: str
     identity: str
     email: str
+    scopes: Scopes
     profile: Profile
     created_at: str
 
@@ -224,17 +225,14 @@ class UserProfileGetResult(PangeaResponseResult):
     mfa_providers: List[str]
     require_mfa: bool
     verified: bool
-    last_login_at: Optional[str] = None
     disabled: Optional[bool] = None
+    last_login_at: Optional[str] = None
 
 
 class UserProfileUpdateRequest(APIRequestModel):
     profile: Profile
     identity: Optional[str] = None
     email: Optional[str] = None
-    require_mfa: Optional[bool] = None
-    mfa_value: Optional[str] = None
-    mfa_providers: Optional[MFAProvider] = None
 
 
 class UserProfileUpdateResult(PangeaResponseResult):
@@ -255,6 +253,7 @@ class UserUpdateRequest(APIRequestModel):
     authenticator: Optional[str] = None
     disabled: Optional[bool] = None
     require_mfa: Optional[bool] = None
+    verified: Optional[bool] = None
 
 
 class UserUpdateResult(PangeaResponseResult):
@@ -294,16 +293,8 @@ class FlowCompleteRequest(APIRequestModel):
 
 
 class FlowCompleteResult(PangeaResponseResult):
-    token: str
-    id: str
-    type: str
-    life: int
-    expire: str
-    identity: str
-    email: str
-    scopes: Scopes
-    profile: Profile
-    created_at: str
+    refresh_token: LoginToken
+    login_token: LoginToken
 
 
 #   - path: authn::/v1/flow/enroll/mfa/complete
@@ -380,6 +371,17 @@ class CommonFlowResult(PangeaResponseResult):
     verify_social: Optional[VerifySocial] = None
 
 
+class FlowResetPasswordRequest(APIRequestModel):
+    flow_id: str
+    password: str
+    cb_state: Optional[str] = None
+    cb_code: Optional[str] = None
+
+
+class FlowResetPasswordResult(CommonFlowResult):
+    pass
+
+
 class FlowEnrollMFAcompleteResult(CommonFlowResult):
     pass
 
@@ -389,6 +391,7 @@ class FlowEnrollMFAcompleteResult(CommonFlowResult):
 class FlowEnrollMFAStartRequest(APIRequestModel):
     flow_id: str
     mfa_provider: MFAProvider
+    phone: str
 
 
 class FlowEnrollMFAStartResult(CommonFlowResult):
@@ -426,6 +429,7 @@ class FlowStartRequest(APIRequestModel):
     cb_uri: str
     email: Optional[str] = None
     flow_types: Optional[List[FlowType]] = None
+    provider: Optional[IDProvider] = None
 
 
 class FlowStartResult(CommonFlowResult):
@@ -459,7 +463,8 @@ class FlowVerifyEmailResult(CommonFlowResult):
 # https://dev.pangea.cloud/docs/api/authn#complete-mfa-verification
 class FlowVerifyMFACompleteRequest(APIRequestModel):
     flow_id: str
-    code: str
+    code: Optional[str] = None
+    cancel: Optional[bool] = None
 
 
 class FlowVerifyMFACompleteResult(CommonFlowResult):
@@ -481,7 +486,8 @@ class FlowVerifyMFAStartResult(CommonFlowResult):
 # https://dev.pangea.cloud/docs/api/authn#sign-in-with-a-password
 class FlowVerifyPasswordRequest(APIRequestModel):
     flow_id: str
-    password: str
+    password: Optional[str] = None
+    cancel: Optional[bool] = None
 
 
 class FlowVerifyPasswordResult(CommonFlowResult):
@@ -529,10 +535,12 @@ class UserMFAStartRequest(APIRequestModel):
     user_id: str
     mfa_provider: MFAProvider
     enroll: Optional[bool] = None
+    phone: Optional[str] = None
 
 
 class UserMFAStartResult(PangeaResponseResult):
-    pass
+    qr_image: str
+    secret: str
 
 
 #   - path: authn::/v1/user/mfa/verify
@@ -561,10 +569,11 @@ class UserVerifyResult(PangeaResponseResult):
     profile: Profile
     scopes: Scopes
     id_provider: IDProvider
+    mfa_providers: List[str]
     require_mfa: bool
     verified: bool
     disabled: bool
-    last_login_at: str
+    last_login_at: Optional[str] = None
 
 
 class ClientSessionInvalidateRequest(APIRequestModel):

--- a/packages/pangea-sdk/tests/integration/test_authn.py
+++ b/packages/pangea-sdk/tests/integration/test_authn.py
@@ -8,7 +8,7 @@ import pangea.exceptions as pexc
 from pangea import PangeaConfig
 from pangea.services.authn.authn import AuthN
 from pangea.services.authn.models import IDProvider
-from pangea.tools_util import TestEnvironment, get_test_domain, get_test_token
+from pangea.tools import TestEnvironment, get_test_domain, get_test_token
 
 TEST_ENVIRONMENT = TestEnvironment.DEVELOP
 
@@ -24,12 +24,6 @@ PROFILE_NEW = {"age": "18"}
 USER_IDENTITY = None  # Will be set once user is created
 
 # tests that should be run in order are named with <letter><number>. Letter to make tests groups and number to order them inside that group
-
-
-def print_api_error(e: pexc.PangeaAPIException):
-    print(f"Summary: {e.response.summary}")
-    for error_field in e.errors:
-        print(f"\t{error_field}")
 
 
 class TestAuthN(unittest.TestCase):
@@ -56,7 +50,7 @@ class TestAuthN(unittest.TestCase):
             self.assertEqual(response.status, "Success")
             self.assertEqual(response.result.profile, PROFILE_NEW)
         except pexc.PangeaAPIException as e:
-            print_api_error(e)
+            print(e)
             self.assertTrue(False)
 
     def test_authn_a2_user_delete(self):
@@ -79,7 +73,7 @@ class TestAuthN(unittest.TestCase):
             self.assertIsNotNone(response.result.active_token)
             self.assertIsNotNone(response.result.refresh_token)
         except pexc.PangeaAPIException as e:
-            print_api_error(e)
+            print(e)
             self.assertTrue(False)
 
     def test_authn_a4_user_profile(self):
@@ -120,7 +114,7 @@ class TestAuthN(unittest.TestCase):
             final_profile.update(PROFILE_NEW)
             self.assertEqual(final_profile, response.result.profile)
         except pexc.PangeaAPIException as e:
-            print_api_error(e)
+            print(e)
             self.assertTrue(False)
 
     def test_authn_a5_user_update(self):


### PR DESCRIPTION
Attempting to see if switching to 3.10 fixes the error from https://gitlab.com/pangeacyber/pangea-python/-/jobs/4018122421

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.7/unittest/__main__.py", line 18, in <module>
    main(module=None)
  File "/usr/local/lib/python3.7/unittest/main.py", line 100, in __init__
    self.parseArgs(argv)
  File "/usr/local/lib/python3.7/unittest/main.py", line 147, in parseArgs
    self.createTests()
  File "/usr/local/lib/python3.7/unittest/main.py", line 159, in createTests
    self.module)
  File "/usr/local/lib/python3.7/unittest/loader.py", line 220, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/local/lib/python3.7/unittest/loader.py", line 220, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/local/lib/python3.7/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/builds/pangeacyber/pangea-python/packages/pangea-sdk/tests/unit/__init__.py", line 1, in <module>
    from .test_signer import *
  File "/builds/pangeacyber/pangea-python/packages/pangea-sdk/tests/unit/test_signer.py", line 4, in <module>
    from pangea.services.audit.signing import Signer
  File "/builds/pangeacyber/pangea-python/packages/pangea-sdk/pangea/services/__init__.py", line 2, in <module>
    from .authn.authn import AuthN
  File "/builds/pangeacyber/pangea-python/packages/pangea-sdk/pangea/services/authn/authn.py", line 14, in <module>
    class AuthN(ServiceBase):
  File "/builds/pangeacyber/pangea-python/packages/pangea-sdk/pangea/services/authn/authn.py", line 52, in AuthN
    class Session(ServiceBase):
  File "/builds/pangeacyber/pangea-python/packages/pangea-sdk/pangea/services/authn/authn.py", line 80, in Session
    size: Optional[int] = None,
TypeError: 'type' object is not subscriptable
```