### PR TITLE
Add homepage and repo URLs (GEA-11296)

### DIFF
--- a/packages/pangea-sdk/pyproject.toml
+++ b/packages/pangea-sdk/pyproject.toml
@@ -5,8 +5,8 @@ description = "Pangea API SDK"
 authors = ["Glenn Gallien <glenn.gallien@pangea.cloud>"]
 license = "MIT"
 readme = "README.md"
-homepage = ""
-repository = ""
+homepage = "https://pangea.cloud/docs/sdk/python/"
+repository = "https://github.com/pangeacyber/pangea-python/tree/main/packages/pangea-sdk"
 keywords = ["Pangea", "SDK", "Audit"]
 classifiers = [
     "Topic :: Software Development",


### PR DESCRIPTION
Package currently cannot be built with the latest version of poetry (v1.7.1) because it has empty homepage and repo URLs.

    $ python -m poetry build

    The Poetry configuration is invalid:
      - data.homepage must be uri
      - data.repository must be uri

This patch fixes this issue by setting these URLs.