### PR TITLE
Close file descriptor in `filepath_reputation()` (GEA-11334)

### DIFF
--- a/packages/pangea-sdk/pangea/services/intel.py
+++ b/packages/pangea-sdk/pangea/services/intel.py
@@ -418,8 +418,9 @@ class FileIntel(ServiceBase):
             )
         """
 
-        data = open(filepath, "rb")
-        hash = hashlib.sha256(data.read()).hexdigest()
+        with open(filepath, "rb") as data:
+            # Can be simplified with `hashlib.file_digest()` in Python v3.11.
+            hash = hashlib.sha256(data.read()).hexdigest()
 
         input = FileReputationRequest(hash=hash, hash_type="sha256", verbose=verbose, raw=raw, provider=provider)
         return self.request.post("v1/reputation", FileReputationResult, data=input.dict(exclude_none=True))


### PR DESCRIPTION
Fixes:
```
$ poetry run python -m unittest tests.integration
........................................................../builds/pangeacyber/pangea-python/packages/pangea-sdk/tests/integration/test_intel.py:91: ResourceWarning: unclosed file <_io.BufferedReader name='./README.md'>
  response = self.intel_file.filepath_reputation(
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```