### PR TITLE
Correct docstrings positions in `PangeaConfig` (GEA-13001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - AuthN list method's filter not being serialized properly.
+- Incorrect docstrings positioning in `PangeaConfig`.
 
 
 ## [3.7.0] - 2024-02-26

--- a/packages/pangea-sdk/pangea/config.py
+++ b/packages/pangea-sdk/pangea/config.py
@@ -9,65 +9,57 @@ from typing import Optional
 class PangeaConfig:
     """Holds run time configuration information used by SDK components."""
 
+    domain: str = "aws.us.pangea.cloud"
     """
     Used to set Pangea domain (and port if needed), it should not include service subdomain
     just for particular use cases when environment = "local", domain could be set to an url including:
     scheme (http:// or https://), subdomain, domain and port.
-
     """
-    domain: str = "aws.us.pangea.cloud"
 
+    environment: str = "production"
     """
     Used to generate service url.
     It should be only 'production' or 'local' in cases of particular services that can run locally as Redact.
-
     """
-    environment: str = "production"
 
+    config_id: Optional[str] = None
     """
     Only used for services that support multiconfig (e.g.: Audit service)
 
     @deprecated("config_id will be deprecated from PangeaConfig. Set it on service initialization instead")
     """
-    config_id: Optional[str] = None
 
+    insecure: bool = False
     """
     Set to true to use plain http
-
     """
-    insecure: bool = False
 
+    request_retries: int = 3
     """
     Number of retries on the initial request
-
     """
-    request_retries: int = 3
 
+    request_backoff: float = 0.5
     """
     Backoff strategy passed to 'requests'
-
     """
-    request_backoff: float = 0.5
 
+    request_timeout: int = 5
     """
     Timeout used on initial request attempts
-
     """
-    request_timeout: int = 5
 
+    poll_result_timeout: int = 30
     """
     Timeout used to poll results after 202 (in secs)
-
     """
-    poll_result_timeout: int = 30
 
+    queued_retry_enabled: bool = True
     """
     Enable queued request retry support
     """
-    queued_retry_enabled: bool = True
 
+    custom_user_agent: Optional[str] = None
     """
     Extra user agent to be added to request user agent
-
     """
-    custom_user_agent: Optional[str] = None


### PR DESCRIPTION
Per PEP 257, docstrings should follow the the variable they describe.