### PR TITLE
chore: update vscode configs (GEA-13469)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ env/
 # editors
 .idea
 .DS_Store
-.vscode
 
 # test coverage
 .coverage

--- a/.vscode/.extensions.json
+++ b/.vscode/.extensions.json
@@ -1,6 +1,0 @@
-{
-    "recommendations": [
-        "ms-python.python",
-        "EditorConfig.editorconfig"
-    ]
-}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "editorconfig.editorconfig",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "ms-python.mypy-type-checker",
+        "ms-python.python"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "editor.formatOnSave": false,
-  "python.formatting.provider": "black",
 
   "python.linting.enabled": true,
   "python.linting.pylintEnabled": false,
@@ -16,5 +15,9 @@
     "*test*.py"
   ],
   "python.testing.pytestEnabled": false,
-  "python.testing.unittestEnabled": true
+  "python.testing.unittestEnabled": true,
+
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  }
 }


### PR DESCRIPTION
"python.formatting.provider" has long been deprecated in favor of the ms-python.black-formatter extension. Also adding more recommended extensions.