### PR TITLE
pangea-sdk: revert `authn.models.Profile` to a dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AuthN user password expiration support.
 
+### Changed
+
+- `pangea.services.authn.models.Profile` has returned to being a
+  `dict[str, str]`, and its `first_name`, `last_name`, and `phone` properties
+  have been deprecated.
+
 ## [4.1.0] - 2024-06-19
 
 ### Added

--- a/packages/pangea-sdk/pangea/services/authn/models.py
+++ b/packages/pangea-sdk/pangea/services/authn/models.py
@@ -5,22 +5,62 @@ from __future__ import annotations
 
 import enum
 from typing import Dict, List, NewType, Optional, Union
+from warnings import warn
 
-from pydantic import BaseModel, ConfigDict
+from typing_extensions import deprecated
 
 import pangea.services.intel as im
+from pangea.deprecated import pangea_deprecated
 from pangea.response import APIRequestModel, APIResponseModel, PangeaResponseResult
 from pangea.services.vault.models.common import JWK, JWKec, JWKrsa
 
 Scopes = NewType("Scopes", List[str])
 
 
-class Profile(BaseModel):
-    first_name: str
-    last_name: Optional[str] = None
-    phone: Optional[str] = None
+class Profile(Dict[str, str]):
+    @property
+    def first_name(self) -> str:
+        warn(
+            '`Profile.first_name` is deprecated. Use `Profile["first_name"]` instead.', DeprecationWarning, stacklevel=2
+        )
+        return self["first_name"]
 
-    model_config = ConfigDict(extra="allow")
+    @first_name.setter
+    def first_name(self, value: str) -> None:
+        warn(
+            '`Profile.first_name` is deprecated. Use `Profile["first_name"]` instead.', DeprecationWarning, stacklevel=2
+        )
+        self["first_name"] = value
+
+    @property
+    def last_name(self) -> str:
+        warn('`Profile.last_name` is deprecated. Use `Profile["last_name"]` instead.', DeprecationWarning, stacklevel=2)
+        return self["last_name"]
+
+    @last_name.setter
+    def last_name(self, value: str) -> None:
+        warn('`Profile.last_name` is deprecated. Use `Profile["last_name"]` instead.', DeprecationWarning, stacklevel=2)
+        self["last_name"] = value
+
+    @property
+    def phone(self) -> str:
+        warn('`Profile.phone` is deprecated. Use `Profile["phone"]` instead.', DeprecationWarning, stacklevel=2)
+        return self["phone"]
+
+    @phone.setter
+    def phone(self, value: str) -> None:
+        warn('`Profile.phone` is deprecated. Use `Profile["phone"]` instead.', DeprecationWarning, stacklevel=2)
+        self["phone"] = value
+
+    @deprecated("`Profile.model_dump()` is deprecated. `Profile` is already a `dict[str, str]`.")
+    @pangea_deprecated(reason="`Profile` is already a `dict[str, str]`.")
+    def model_dump(self, *, exclude_none: bool = False) -> dict[str, str]:
+        warn(
+            "`Profile.model_dump()` is deprecated. `Profile` is already a `dict[str, str]`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self
 
 
 class ClientPasswordChangeRequest(APIRequestModel):
@@ -65,7 +105,7 @@ class SessionToken(PangeaResponseResult):
     identity: str
     email: str
     scopes: Optional[Scopes] = None
-    profile: Profile
+    profile: Union[Profile, Dict[str, str]]
     created_at: str
     intelligence: Optional[Intelligence] = None
 
@@ -174,7 +214,7 @@ class User(PangeaResponseResult):
     username: str
     """A username."""
 
-    profile: Profile
+    profile: Union[Profile, Dict[str, str]]
     """A user profile as a collection of string properties."""
 
     verified: bool
@@ -207,7 +247,7 @@ class UserCreateRequest(APIRequestModel):
     email: str
     """An email address."""
 
-    profile: Profile
+    profile: Union[Profile, Dict[str, str]]
     """A user profile as a collection of string properties."""
 
     username: Optional[str] = None
@@ -397,7 +437,7 @@ class UserProfileGetResult(User):
 
 
 class UserProfileUpdateRequest(APIRequestModel):
-    profile: Profile
+    profile: Union[Profile, Dict[str, str]]
     """Updates to a user profile."""
 
     id: Optional[str] = None
@@ -583,7 +623,7 @@ class FlowUpdateDataPassword(APIRequestModel):
 
 
 class FlowUpdateDataProfile(APIRequestModel):
-    profile: Profile
+    profile: Union[Profile, Dict[str, str]]
 
 
 class FlowUpdateDataProvisionalEnrollment(APIRequestModel):
@@ -705,7 +745,7 @@ class SessionItem(APIResponseModel):
     expire: str
     email: str
     scopes: Optional[Scopes] = None
-    profile: Profile
+    profile: Union[Profile, Dict[str, str]]
     created_at: str
     active_token: Optional[SessionToken] = None
 

--- a/packages/pangea-sdk/tests/integration/asyncio/test_authn.py
+++ b/packages/pangea-sdk/tests/integration/asyncio/test_authn.py
@@ -163,12 +163,12 @@ class TestAuthN(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(USER_ID, response.result.id)
             self.assertEqual(EMAIL_TEST, response.result.email)
             final_profile: dict[str, str] = {}
-            final_profile.update(PROFILE_OLD.model_dump(exclude_none=True))
-            final_profile.update(PROFILE_NEW.model_dump(exclude_none=True))
+            final_profile.update(PROFILE_OLD)
+            final_profile.update(PROFILE_NEW)
             self.assertEqual(m.Profile(**final_profile), response.result.profile)
         except pe.PangeaAPIException as e:
             print(e)
-            self.assertTrue(False)
+            raise
 
     async def authn_a5_user_update(self):
         response = await self.authn.user.update(email=EMAIL_TEST, disabled=False)

--- a/packages/pangea-sdk/tests/integration/test_authn.py
+++ b/packages/pangea-sdk/tests/integration/test_authn.py
@@ -147,12 +147,12 @@ class TestAuthN(unittest.TestCase):
             self.assertEqual(USER_ID, response.result.id)
             self.assertEqual(EMAIL_TEST, response.result.email)
             final_profile: dict[str, str] = {}
-            final_profile.update(PROFILE_OLD.model_dump(exclude_none=True))
-            final_profile.update(PROFILE_NEW.model_dump(exclude_none=True))
+            final_profile.update(PROFILE_OLD)
+            final_profile.update(PROFILE_NEW)
             self.assertEqual(m.Profile(**final_profile), response.result.profile)
         except pe.PangeaAPIException as e:
             print(e)
-            self.assertTrue(False)
+            raise
 
     def test_authn_a5_user_update(self):
         response = self.authn.user.update(email=EMAIL_TEST, disabled=False)

--- a/packages/pangea-sdk/tests/unit/__init__.py
+++ b/packages/pangea-sdk/tests/unit/__init__.py
@@ -1,2 +1,3 @@
 from .test_enum import TestEnums
+from .test_models import TestModels
 from .test_signer import TestSigner

--- a/packages/pangea-sdk/tests/unit/test_models.py
+++ b/packages/pangea-sdk/tests/unit/test_models.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from pangea.services.authn.models import FlowUpdateDataProfile, Profile
+
+
+class TestModels(TestCase):
+    def test_authn_profile(self) -> None:
+        profile: dict[str, str] = {"first_name": "Name", "last_name": "Last"}
+        profile["foo"] = "bar"
+        Profile(profile)
+        FlowUpdateDataProfile(profile=profile)


### PR DESCRIPTION
Deprecate the `first_name`, `last_name`, and `phone` properties of `Profile` and have it be nothing more than a `dict[str, str]`.

Partial revert of 35bc9ff9a07e155968394abd8f425b4140116728.