### PR TITLE
pangea-sdk: remove beta tags on AuthZ `/list-resources` and `/list-subjects` (PAN-16985)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Dependency on the asyncio pypi package.
+- Lingering beta tags on AuthZ `/list-resources` and `/list-subjects` endpoints.
 
 ## 4.2.0 - 2024-07-16
 

--- a/packages/pangea-sdk/pangea/asyncio/services/authz.py
+++ b/packages/pangea-sdk/pangea/asyncio/services/authz.py
@@ -198,7 +198,7 @@ class AuthZAsync(ServiceBaseAsync):
     async def list_resources(
         self, type: str, action: str, subject: Subject, attributes: Optional[Dict[str, Any]] = None
     ) -> PangeaResponse[ListResourcesResult]:
-        """List resources. (Beta)
+        """List resources.
 
         Given a type, action, and subject, list all the resources in the
         type that the subject has access to the action with.
@@ -233,7 +233,7 @@ class AuthZAsync(ServiceBaseAsync):
     async def list_subjects(
         self, resource: Resource, action: str, attributes: Optional[Dict[str, Any]] = None
     ) -> PangeaResponse[ListSubjectsResult]:
-        """List subjects. (Beta)
+        """List subjects.
 
         Given a resource and an action, return the list of subjects who have
         access to the action for the given resource.

--- a/packages/pangea-sdk/pangea/services/authz.py
+++ b/packages/pangea-sdk/pangea/services/authz.py
@@ -316,7 +316,7 @@ class AuthZ(ServiceBase):
     def list_resources(
         self, type: str, action: str, subject: Subject, attributes: Optional[Dict[str, Any]] = None
     ) -> PangeaResponse[ListResourcesResult]:
-        """List resources. (Beta)
+        """List resources.
 
         Given a type, action, and subject, list all the resources in the
         type that the subject has access to the action with.
@@ -351,7 +351,7 @@ class AuthZ(ServiceBase):
     def list_subjects(
         self, resource: Resource, action: str, attributes: Optional[Dict[str, Any]] = None
     ) -> PangeaResponse[ListSubjectsResult]:
-        """List subjects. (Beta)
+        """List subjects.
 
         Given a resource and an action, return the list of subjects who have
         access to the action for the given resource.


### PR DESCRIPTION
Seems these were accidentally added in bcf841f?