### PR TITLE
pangea-sdk: make `Audit.fix_consistency_proofs` private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- `Audit.fix_consistency_proofs` is now a private method.
+
 ## 5.1.0 - 2024-10-16
 
 ### Added

--- a/packages/pangea-sdk/pangea/asyncio/services/audit.py
+++ b/packages/pangea-sdk/pangea/asyncio/services/audit.py
@@ -632,9 +632,9 @@ class AuditAsync(ServiceBaseAsync, AuditBase):
             if pub_root is not None:
                 self.pub_roots[tree_size] = pub_root
 
-        await self.fix_consistency_proofs(tree_sizes)
+        await self._fix_consistency_proofs(tree_sizes)
 
-    async def fix_consistency_proofs(self, tree_sizes: Iterable[int]):
+    async def _fix_consistency_proofs(self, tree_sizes: Iterable[int]) -> None:
         # on very rare occasions, the consistency proof in Arweave may be wrong
         # override it with the proof from pangea (not the root hash, just the proof)
         for tree_size in tree_sizes:

--- a/packages/pangea-sdk/pangea/services/audit/audit.py
+++ b/packages/pangea-sdk/pangea/services/audit/audit.py
@@ -961,9 +961,9 @@ class Audit(ServiceBase, AuditBase):
             if pub_root is not None:
                 self.pub_roots[tree_size] = pub_root
 
-        self.fix_consistency_proofs(tree_sizes)
+        self._fix_consistency_proofs(tree_sizes)
 
-    def fix_consistency_proofs(self, tree_sizes: Iterable[int]):
+    def _fix_consistency_proofs(self, tree_sizes: Iterable[int]) -> None:
         # on very rare occasions, the consistency proof in Arweave may be wrong
         # override it with the proof from pangea (not the root hash, just the proof)
         for tree_size in tree_sizes:


### PR DESCRIPTION
Don't believe this was ever intended to be used by anyone downstream.