### PR TITLE
pangea-sdk: update Prompt Guard to v1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AI Guard: updated to v1.
 - Prompt Guard: `type` may be an empty string.
+- Prompt Guard: updated to v1.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- AI Guard: support for `llm_input`, `llm_info`, and `log_fields`.
+
 ### Changed
 
 - AI Guard: updated to v1.

--- a/packages/pangea-sdk/pangea/asyncio/services/ai_guard.py
+++ b/packages/pangea-sdk/pangea/asyncio/services/ai_guard.py
@@ -7,7 +7,7 @@ from typing_extensions import TypeVar
 from pangea.asyncio.services.base import ServiceBaseAsync
 from pangea.config import PangeaConfig
 from pangea.response import PangeaResponse
-from pangea.services.ai_guard import TextGuardResult
+from pangea.services.ai_guard import LogFields, TextGuardResult
 
 _T = TypeVar("_T")
 
@@ -54,10 +54,12 @@ class AIGuardAsync(ServiceBaseAsync):
     @overload
     async def guard_text(
         self,
-        text_or_messages: str,
+        text: str,
         *,
-        recipe: str = "pangea_prompt_guard",
-        debug: bool = False,
+        recipe: str | None = None,
+        debug: bool | None = None,
+        llm_info: str | None = None,
+        log_fields: LogFields | None = None,
     ) -> PangeaResponse[TextGuardResult[None]]:
         """
         Text Guard for scanning LLM inputs and outputs
@@ -76,6 +78,8 @@ class AIGuardAsync(ServiceBaseAsync):
                 are to be applied to the text, such as defang malicious URLs.
             debug: Setting this value to true will provide a detailed analysis
                 of the text data
+            llm_info: Short string hint for the LLM Provider information
+            log_field: Additional fields to include in activity log
 
         Examples:
             response = await ai_guard.guard_text("text")
@@ -84,10 +88,12 @@ class AIGuardAsync(ServiceBaseAsync):
     @overload
     async def guard_text(
         self,
-        text_or_messages: _T,
         *,
-        recipe: str = "pangea_prompt_guard",
-        debug: bool = False,
+        messages: _T,
+        recipe: str | None = None,
+        debug: bool | None = None,
+        llm_info: str | None = None,
+        log_fields: LogFields | None = None,
     ) -> PangeaResponse[TextGuardResult[_T]]:
         """
         Text Guard for scanning LLM inputs and outputs
@@ -98,27 +104,31 @@ class AIGuardAsync(ServiceBaseAsync):
         OperationId: ai_guard_post_v1_text_guard
 
         Args:
-            text_or_messages: Structured data to be scanned by AI Guard for PII,
-                sensitive data, malicious content, and other data types defined
-                by the configuration. Supports processing up to 10KB of text.
+            messages: Structured messages data to be scanned by AI Guard for
+                PII, sensitive data, malicious content, and other data types
+                defined by the configuration. Supports processing up to 10KB of
+                JSON text
             recipe: Recipe key of a configuration of data types and settings
                 defined in the Pangea User Console. It specifies the rules that
                 are to be applied to the text, such as defang malicious URLs.
             debug: Setting this value to true will provide a detailed analysis
                 of the text data
+            llm_info: Short string hint for the LLM Provider information
+            log_field: Additional fields to include in activity log
 
         Examples:
-            response = await ai_guard.guard_text([
-                {"role": "user", "content": "hello world"}
-            ])
+            response = await ai_guard.guard_text(messages=[{"role": "user", "content": "hello world"}])
         """
 
+    @overload
     async def guard_text(
         self,
-        text_or_messages: str | _T,
         *,
-        recipe: str = "pangea_prompt_guard",
-        debug: bool = False,
+        llm_input: _T,
+        recipe: str | None = None,
+        debug: bool | None = None,
+        llm_info: str | None = None,
+        log_fields: LogFields | None = None,
     ) -> PangeaResponse[TextGuardResult[_T]]:
         """
         Text Guard for scanning LLM inputs and outputs
@@ -129,25 +139,83 @@ class AIGuardAsync(ServiceBaseAsync):
         OperationId: ai_guard_post_v1_text_guard
 
         Args:
-            text_or_messages: Text or structured data to be scanned by AI Guard
-                for PII, sensitive data, malicious content, and other data types
-                defined by the configuration. Supports processing up to 10KB of text.
+            llm_input: Structured full llm payload data to be scanned by AI
+                Guard for PII, sensitive data, malicious content, and other data
+                types defined by the configuration. Supports processing up to
+                10KB of JSON text
             recipe: Recipe key of a configuration of data types and settings
                 defined in the Pangea User Console. It specifies the rules that
                 are to be applied to the text, such as defang malicious URLs.
             debug: Setting this value to true will provide a detailed analysis
                 of the text data
+            llm_info: Short string hint for the LLM Provider information
+            log_field: Additional fields to include in activity log
+
+        Examples:
+            response = await ai_guard.guard_text(
+                llm_input={"model": "gpt-4o", "messages": [{"role": "user", "content": "hello world"}]}
+            )
+        """
+
+    async def guard_text(  # type: ignore[misc]
+        self,
+        text: str | None = None,
+        *,
+        messages: _T | None = None,
+        llm_input: _T | None = None,
+        recipe: str | None = None,
+        debug: bool | None = None,
+        llm_info: str | None = None,
+        log_fields: LogFields | None = None,
+    ) -> PangeaResponse[TextGuardResult[None]]:
+        """
+        Text Guard for scanning LLM inputs and outputs
+
+        Analyze and redact text to avoid manipulation of the model, addition of
+        malicious content, and other undesirable data transfers.
+
+        OperationId: ai_guard_post_v1_text_guard
+
+        Args:
+            text: Text to be scanned by AI Guard for PII, sensitive data,
+                malicious content, and other data types defined by the
+                configuration. Supports processing up to 10KB of text.
+            messages: Structured messages data to be scanned by AI Guard for
+                PII, sensitive data, malicious content, and other data types
+                defined by the configuration. Supports processing up to 10KB of
+                JSON text
+            llm_input: Structured full llm payload data to be scanned by AI
+                Guard for PII, sensitive data, malicious content, and other data
+                types defined by the configuration. Supports processing up to
+                10KB of JSON text
+            recipe: Recipe key of a configuration of data types and settings
+                defined in the Pangea User Console. It specifies the rules that
+                are to be applied to the text, such as defang malicious URLs.
+            debug: Setting this value to true will provide a detailed analysis
+                of the text data
+            llm_info: Short string hint for the LLM Provider information
+            log_field: Additional fields to include in activity log
 
         Examples:
             response = await ai_guard.guard_text("text")
         """
 
+        if not any((text, messages, llm_input)):
+            raise ValueError("Exactly one of `text`, `messages`, or `llm_input` must be given")
+
+        if sum((text is not None, messages is not None, llm_input is not None)) > 1:
+            raise ValueError("Only one of `text`, `messages`, or `llm_input` can be given at once")
+
         return await self.request.post(
             "v1/text/guard",
             TextGuardResult,
             data={
-                "text" if isinstance(text_or_messages, str) else "messages": text_or_messages,
+                "text": text,
+                "messages": messages,
+                "llm_input": llm_input,
                 "recipe": recipe,
                 "debug": debug,
+                "llm_info": llm_info,
+                "log_fields": log_fields,
             },
         )

--- a/packages/pangea-sdk/pangea/asyncio/services/prompt_guard.py
+++ b/packages/pangea-sdk/pangea/asyncio/services/prompt_guard.py
@@ -59,13 +59,11 @@ class PromptGuardAsync(ServiceBaseAsync):
         classify: bool | None = None,
     ) -> PangeaResponse[GuardResult]:
         """
-        Guard (Beta)
+        Guard
 
         Guard messages.
 
-        How to install a [Beta release](https://pangea.cloud/docs/sdk/python/#beta-releases).
-
-        OperationId: prompt_guard_post_v1beta_guard
+        OperationId: prompt_guard_post_v1_guard
 
         Args:
             messages: Prompt content and role array in JSON format. The
@@ -80,7 +78,7 @@ class PromptGuardAsync(ServiceBaseAsync):
         """
 
         return await self.request.post(
-            "v1beta/guard",
+            "v1/guard",
             GuardResult,
             data={"messages": messages, "analyzers": analyzers, "classify": classify},
         )

--- a/packages/pangea-sdk/pangea/services/prompt_guard.py
+++ b/packages/pangea-sdk/pangea/services/prompt_guard.py
@@ -93,13 +93,11 @@ class PromptGuard(ServiceBase):
         classify: bool | None = None,
     ) -> PangeaResponse[GuardResult]:
         """
-        Guard (Beta)
+        Guard
 
         Guard messages.
 
-        How to install a [Beta release](https://pangea.cloud/docs/sdk/python/#beta-releases).
-
-        OperationId: prompt_guard_post_v1beta_guard
+        OperationId: prompt_guard_post_v1_guard
 
         Args:
             messages: Prompt content and role array in JSON format. The
@@ -114,7 +112,7 @@ class PromptGuard(ServiceBase):
         """
 
         return self.request.post(
-            "v1beta/guard",
+            "v1/guard",
             GuardResult,
             data={"messages": messages, "analyzers": analyzers, "classify": classify},
         )

--- a/packages/pangea-sdk/tests/integration/asyncio/test_ai_guard.py
+++ b/packages/pangea-sdk/tests/integration/asyncio/test_ai_guard.py
@@ -31,26 +31,24 @@ class TestAIGuardAsync(unittest.IsolatedAsyncioTestCase):
             assert response.result.detectors.prompt_injection.detected is False
             assert response.result.detectors.prompt_injection.data is None
 
-        assert response.result.detectors.pii_entity
-        assert response.result.detectors.pii_entity.detected is False
-        assert response.result.detectors.pii_entity.data is None
+        if response.result.detectors.pii_entity:
+            assert response.result.detectors.pii_entity.detected is False
+            assert response.result.detectors.pii_entity.data is None
 
         if response.result.detectors.malicious_entity:
             assert response.result.detectors.malicious_entity.detected is False
             assert response.result.detectors.malicious_entity.data is None
 
-        response = await self.client.guard_text("security@pangea.cloud")
+    async def test_text_guard_messages(self) -> None:
+        response = await self.client.guard_text(messages=[{"role": "user", "content": "hello world"}])
         assert response.status == "Success"
         assert response.result
-        assert response.result.prompt_text
-        assert response.result.detectors.pii_entity
-        assert response.result.detectors.pii_entity.detected
-        assert response.result.detectors.pii_entity.data
-        assert response.result.detectors.pii_entity.data.entities
-        assert len(response.result.detectors.pii_entity.data.entities) == 1
+        assert response.result.prompt_messages
 
-    async def test_text_guard_structured(self) -> None:
-        response = await self.client.guard_text([{"role": "user", "content": "hello world"}])
+    async def test_text_guard_llm_input(self) -> None:
+        response = await self.client.guard_text(
+            llm_input={"model": "gpt-4o", "messages": [{"role": "user", "content": "hello world"}]}
+        )
         assert response.status == "Success"
         assert response.result
         assert response.result.prompt_messages

--- a/packages/pangea-sdk/tests/integration/test_ai_guard.py
+++ b/packages/pangea-sdk/tests/integration/test_ai_guard.py
@@ -32,18 +32,16 @@ class TestAIGuard(unittest.TestCase):
             assert response.result.detectors.pii_entity.detected is False
             assert response.result.detectors.pii_entity.data is None
 
-        response = self.client.guard_text("security@pangea.cloud")
+    def test_text_guard_messages(self) -> None:
+        response = self.client.guard_text(messages=[{"role": "user", "content": "hello world"}])
         assert response.status == "Success"
         assert response.result
-        assert response.result.prompt_text
-        assert response.result.detectors.pii_entity
-        assert response.result.detectors.pii_entity.detected
-        assert response.result.detectors.pii_entity.data
-        assert response.result.detectors.pii_entity.data.entities
-        assert len(response.result.detectors.pii_entity.data.entities) == 1
+        assert response.result.prompt_messages
 
-    def test_text_guard_structured(self) -> None:
-        response = self.client.guard_text([{"role": "user", "content": "hello world"}])
+    def test_text_guard_llm_input(self) -> None:
+        response = self.client.guard_text(
+            llm_input={"model": "gpt-4o", "messages": [{"role": "user", "content": "hello world"}]}
+        )
         assert response.status == "Success"
         assert response.result
         assert response.result.prompt_messages


### PR DESCRIPTION
For AI Guard, I had to redo the overloads because there isn't really a way to differentiate between a `messages` object and a `llm_input` one. So instead, callers now need to name which parameter they are using. For convenience, the positional argument case is still the `text` one.